### PR TITLE
Improve profiling code and README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,43 @@
-# aml_data_profiling
+# AML Data Profiling
+
+This repository contains a small collection of **profilers** used to clean and
+standardise CSV files generated from clinical research data. Each profiler
+focuses on a single domain (demographics, death, diagnosis and treatment) and
+produces a cleaned CSV ready for analysis.
+
+## Installation
+
+1. Create a Python environment (virtualenv or conda).
+2. Install the dependencies:
+
+   ```bash
+   pip install -r requirements.txt
+   ```
+
+## Usage
+
+The application is driven by environment variables. The most common ones are:
+
+| Variable | Default | Description |
+|----------|---------|-------------|
+| `CSV_FOLDER_PATH` | `data/csv` | Directory where raw CSV files are located |
+| `OUTPUT_FOLDER_PATH` | `data/output` | Directory to write cleaned files |
+| `FILE_NAME` | – | Name of the CSV file to process |
+| `PROFILE` | `demo_demographic` | Which profiler to use (`demo_demographic`, `death`, `diagnosis`, or `treatment`) |
+
+Set the variables and run:
+
+```bash
+python main.py
+```
+
+## Extending
+
+To add a new profiler create a subclass of `BaseProfiler` in the `profilers`
+package and implement the `clean_data` method. The base class handles loading
+and saving the file so you only need to focus on cleaning logic.
+
+## License
+
+This project is licensed under the MIT License – see the [LICENSE](LICENSE)
+file for details.

--- a/main.py
+++ b/main.py
@@ -1,33 +1,40 @@
+"""Entry point for running the data profilers."""
+
+from dotenv import load_dotenv
+import os
+
 from profilers.demo_profiler import DemoDemographicProfiler
 from profilers.death_profiler import DeathProfiler
 from profilers.diag_profiler import DiagnosisProfiler
 from profilers.treatment_profiler import TreatmentProfiler
-# load the loadenv
-from dotenv import load_dotenv
-import os
+
 
 load_dotenv()
 
 
-# CLI handler
-def main():
+def main() -> None:
+    """Load configuration, select the profiler and run it."""
 
     csv_folder_path = os.getenv("CSV_FOLDER_PATH", "data/csv")
     output_folder_path = os.getenv("OUTPUT_FOLDER_PATH", "data/output")
     filename = os.getenv("FILE_NAME")
     profile = os.getenv("PROFILE", "demo_demographic")
 
-    print(filename)
+    # Map profile names to their corresponding classes
     profiler_map = {
         "demo_demographic": DemoDemographicProfiler,
         "death": DeathProfiler,
         "diagnosis": DiagnosisProfiler,
-        "treatment": TreatmentProfiler
+        "treatment": TreatmentProfiler,
     }
 
     profiler_class = profiler_map.get(profile)
+    if not profiler_class:
+        raise ValueError(f"Unknown profile '{profile}'")
+
     profiler = profiler_class(csv_folder_path, output_folder_path, filename)
     profiler.process()
+
 
 if __name__ == "__main__":
     main()

--- a/profiler.py
+++ b/profiler.py
@@ -1,43 +1,38 @@
+"""Base class and helpers for CSV profiling."""
+
 import os
-import pandas as pd
 from abc import ABC, abstractmethod
+from typing import Optional
+
+import pandas as pd
+
 
 class BaseProfiler(ABC):
-    """
-    This class defines the structure for profiling data, including loading,
-    cleaning, and saving data.
-    """
-    def __init__(self, input_dir: str, output_dir: str, filename: str):
+    """Common functionality for profilers working with CSV files."""
+
+    def __init__(self, input_dir: str, output_dir: str, filename: str) -> None:
+        """Store input and output paths for the profiling run."""
         self.input_path = os.path.join(input_dir, filename)
         self.output_path = os.path.join(output_dir, filename)
-        print(f"Input Path: {self.input_path}")
-        self.data = None
+        self.data: Optional[pd.DataFrame] = None
 
-    def load_data(self):
-        """
-        This method reads a CSV file into a pandas DataFrame.
-        """
-        self.data = pd.read_csv(self.input_path)
+    def load_data(self) -> None:
+        """Read the CSV file into ``self.data`` using string types."""
+        self.data = pd.read_csv(self.input_path, dtype=str, low_memory=False)
 
     @abstractmethod
-    def clean_data(self):
-        """
-        This method should be implemented to clean the data.
-        """
-        pass
+    def clean_data(self) -> None:
+        """Implement data cleaning logic in subclasses."""
 
-    def save_data(self):
-        """
-        This method saves the cleaned DataFrame to a CSV file.
-        """
+    def save_data(self) -> None:
+        """Write ``self.data`` to ``self.output_path``."""
         os.makedirs(os.path.dirname(self.output_path), exist_ok=True)
-        self.data.to_csv(self.output_path, index=False)
+        if self.data is not None:
+            self.data.to_csv(self.output_path, index=False)
 
-    def process(self):
-        """
-        This method orchestrates the data profiling process by calling
-        load_data, clean_data, and save_data in sequence.
-        """
+    def process(self) -> None:
+        """Run the standard profiling workflow."""
         self.load_data()
         self.clean_data()
         self.save_data()
+

--- a/profilers/death_profiler.py
+++ b/profilers/death_profiler.py
@@ -1,16 +1,23 @@
+"""Profiler that filters patients confirmed dead."""
+
+import pandas as pd
+
 from profiler import BaseProfiler
 
-class DeathProfiler(BaseProfiler):
-    def clean_data(self):
-        df = self.data
 
-        # Keep only rows where censor_status_death == 'dead'
+class DeathProfiler(BaseProfiler):
+    """Select only records for deceased patients."""
+
+    def clean_data(self) -> None:
+        df = self.data
+        assert df is not None
+
+        # Filter for rows marked as dead
         df = df[df["censor_status_death"].astype(str).str.lower() == "dead"]
 
-        # Rename patient_id to ehealth_id
+        # Standardise patient identifier
         df = df.rename(columns={"patient_id": "ehealth_id"})
-
-        # Replace 'PT' with 'EHH' in ehealth_id
         df["ehealth_id"] = df["ehealth_id"].astype(str).str.replace("PT", "EHH", regex=False)
 
         self.data = df
+

--- a/profilers/demo_profiler.py
+++ b/profilers/demo_profiler.py
@@ -1,22 +1,30 @@
-from profiler import BaseProfiler
-import pandas as pd
+"""Profiler for demographic data."""
+
 from datetime import datetime
+
+import pandas as pd
+
+from profiler import BaseProfiler
 
 
 class DemoDemographicProfiler(BaseProfiler):
-    def clean_data(self):
-        df = self.data
+    """Clean demographic CSV files."""
 
-        # Keep only specific columns
+    def clean_data(self) -> None:
+        df = self.data
+        assert df is not None
+
+        # Keep only the relevant columns
         columns_to_keep = ["ehealth_id", "sex", "age", "occupation_holder", "dob"]
         df = df[columns_to_keep]
 
-        # Drop rows with missing values in required columns
+        # Drop rows missing required values
         df = df.dropna(subset=columns_to_keep)
 
-        # Convert 'sex' to uppercase
+        # Normalise columns
         df["sex"] = df["sex"].astype(str).str.upper()
         current_year = datetime.now().year
         df["dob"] = (current_year - df["age"].astype(int)).astype(str) + "-01-01"
 
         self.data = df
+

--- a/profilers/diag_profiler.py
+++ b/profilers/diag_profiler.py
@@ -1,16 +1,27 @@
+"""Profiler for diagnosis related fields."""
+
 from profiler import BaseProfiler
 
+
 class DiagnosisProfiler(BaseProfiler):
-    def clean_data(self):
+    """Clean diagnosis CSV files."""
+
+    def clean_data(self) -> None:
         df = self.data
-        # Remove 'M-' prefix from morphology_code
+        assert df is not None
+
+        # Remove the "M-" prefix from morphology codes
         df["morphology_code_dx"] = df["morphology_code_dx"].astype(str).str.replace("M-", "", regex=False)
-        # Map sample_source values to standardized codes
+
+        # Standardise sample_source values
         source_mapping = {
             "bone marrow biopsy": "287550000",
             "flow cytometry": "64444005",
-            "lymph node biopsy": "396487001"
+            "lymph node biopsy": "396487001",
         }
-        df["sample_source"] = df["method_dx"].map(lambda x: source_mapping.get(x.lower(), x) if isinstance(x, str) else x)
+        df["sample_source"] = df["method_dx"].map(
+            lambda x: source_mapping.get(x.lower(), x) if isinstance(x, str) else x
+        )
 
         self.data = df
+

--- a/profilers/treatment_profiler.py
+++ b/profilers/treatment_profiler.py
@@ -1,10 +1,16 @@
+"""Profiler that maps treatment information to standard codes."""
+
 from profiler import BaseProfiler
 
-class TreatmentProfiler(BaseProfiler):
-    def clean_data(self):
-        df = self.data
 
-        # Map drug_name_tx to standard codes
+class TreatmentProfiler(BaseProfiler):
+    """Clean treatment related CSV files."""
+
+    def clean_data(self) -> None:
+        df = self.data
+        assert df is not None
+
+        # Map raw drug names to standardised codes
         drug_mapping = {
             "acalabrutinib": "1986808",
             "bendamustine": "134547",
@@ -16,18 +22,23 @@ class TreatmentProfiler(BaseProfiler):
             "predinisolone": "OMOP880540",
             "rituximab": "121191",
             "venetoclax": "1747556",
-            "zanubrutinib": "2262435"
+            "zanubrutinib": "2262435",
         }
-        df["drug_code_tx"] = df["drug_name_tx"].map(lambda x: drug_mapping.get(x.lower(), x) if isinstance(x, str) else x)
+        df["drug_code_tx"] = df["drug_name_tx"].map(
+            lambda x: drug_mapping.get(x.lower(), x) if isinstance(x, str) else x
+        )
 
-        # Map status_tx to standard codes in a new column
+        # Map treatment status to standard codes
         status_mapping = {
             "active surveillance": "424313000",
             "palliative care": "103735009",
             "remission": "OMOP4997717",
             "treatment": "202111000000106",
-            "under review": "721241000000109"
+            "under review": "721241000000109",
         }
-        df["status_tx_code"] = df["status_tx"].map(lambda x: status_mapping.get(x.lower(), x) if isinstance(x, str) else x)
+        df["status_tx_code"] = df["status_tx"].map(
+            lambda x: status_mapping.get(x.lower(), x) if isinstance(x, str) else x
+        )
 
         self.data = df
+


### PR DESCRIPTION
## Summary
- document installation and usage in `README.md`
- add docstrings and type hints
- speed up CSV loading by disabling dtype inference
- clean up profiler implementations

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_684712967ba4832a8ca874139cd48dcc